### PR TITLE
EOF error fixed.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,4 +21,9 @@ for lib in "${required_libraries[@]}"; do
     fi
 done
 
-curl -sSL https://raw.githubusercontent.com/ItsAML/MarzbanEZNode/main/curlscript.py | python3 -
+# Saving Script into > curlscript.py
+curl -sSL https://raw.githubusercontent.com/ItsAML/MarzbanEZNode/main/curlscript.py > curlscript.py
+# Running previously saved script
+python3 curlscript.py
+# (OPTIONAL) removing script
+rm curlscript.py


### PR DESCRIPTION
Trying to run script file and curling he script in one line of bash command will cause some EOF error.
Saving and running script should be in different stages to avoid EOF error.